### PR TITLE
🐛resolve build errors in testing due to new css.protoascii

### DIFF
--- a/validator/java/src/main/bin/fetchAMPResources.sh
+++ b/validator/java/src/main/bin/fetchAMPResources.sh
@@ -33,6 +33,9 @@ else
     echo "Append validator main proto asci files"
     cat ../validator-main.protoascii >> ${AMP_RESOURCES_DIR}/${AMP_VALIDATOR_PROTOASCII};
 
+    echo "Append validator css proto ascii files"
+    cat ../validator-css.protoascii >> ${AMP_RESOURCES_DIR}/${AMP_VALIDATOR_PROTOASCII};
+
     echo "Concatenate all extension proto asci files"
     for i in `find ../../extensions -name "*.protoascii"`; do
         echo $i;

--- a/validator/java/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
+++ b/validator/java/src/test/java/dev/amp/validator/parser/AMPHtmlParserTest.java
@@ -1056,21 +1056,21 @@ public class AMPHtmlParserTest {
 //        }
   }
 
-  @Test
-  public void testCdataViolatesBlacklist() {
-    try {
-      String inputHtml =
-        readFile(
-          "test-cases/css/testCdataViolatesBlacklist.html");
-      final int maxNode = 10000;
-      ValidatorProtos.ValidationResult result =
-        ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
-      Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
-      Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CDATA_VIOLATES_BLACKLIST);
-    } catch (final IOException ex) {
-      ex.printStackTrace();
-    }
-  }
+//  @Test
+//  public void testCdataViolatesBlacklist() {
+//    try {
+//      String inputHtml =
+//        readFile(
+//          "test-cases/css/testCdataViolatesBlacklist.html");
+//      final int maxNode = 10000;
+//      ValidatorProtos.ValidationResult result =
+//        ampHtmlParser.parse(inputHtml, ValidatorProtos.HtmlFormat.Code.AMP4EMAIL, ExitCondition.FULL_PARSING, maxNode);
+//      Assert.assertEquals(result.getErrorsCount(), 1, "Expecting to have 1 error");
+//      Assert.assertTrue(result.getErrors(0).getCode() == ValidatorProtos.ValidationError.Code.CDATA_VIOLATES_BLACKLIST);
+//    } catch (final IOException ex) {
+//      ex.printStackTrace();
+//    }
+//  }
 
   public static String readFile(@Nonnull final String filePath) throws IOException {
     final StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
- added a cat to roll in css.protoascii from validator/ level
- removed a test, due to changes in style's blacklist (no more fail on !important attribute)